### PR TITLE
Implement profanity checking middleware

### DIFF
--- a/ideeenbord-mvp/ideeenbord/composables/ideas/useIdeas.ts
+++ b/ideeenbord-mvp/ideeenbord/composables/ideas/useIdeas.ts
@@ -41,8 +41,12 @@ export function useIdeas(brandId: number) {
       await fetchIdeas();
       triggerByKey("idea-posted");
     } catch (err: any) {
-      error.value = err?.message || "Failed to submit idea.";
-      triggerByKey("idea-failed");
+      error.value = err?.data?.message || err?.message || "Failed to submit idea.";
+      if (error.value && error.value.includes("Scheldwoorden")) {
+        triggerByKey("profanity-detected");
+      } else {
+        triggerByKey("idea-failed");
+      }
     }
   }
 

--- a/ideeenbord-mvp/ideeenbord/pages/brands/request.vue
+++ b/ideeenbord-mvp/ideeenbord/pages/brands/request.vue
@@ -30,7 +30,11 @@ async function handleSubmit() {
     await requestBrand(form.value);
     triggerByKey("request-submitted");
   } catch (e) {
-    triggerByKey("request-failed");
+    if (typeof error.value === "string" && error.value.includes("Scheldwoorden")) {
+      triggerByKey("profanity-detected");
+    } else {
+      triggerByKey("request-failed");
+    }
   }
 }
 </script>

--- a/ideeenbord-mvp/ideeenbord/pages/register.vue
+++ b/ideeenbord-mvp/ideeenbord/pages/register.vue
@@ -36,7 +36,11 @@ async function handleSubmit() {
   if (success) {
     triggerByKey("register-success");
   } else {
-    triggerByKey("register-failed");
+    if (error.value && error.value.includes("Scheldwoorden")) {
+      triggerByKey("profanity-detected");
+    } else {
+      triggerByKey("register-failed");
+    }
   }
 }
 </script>

--- a/ideeenbord-mvp/ideeenbord/utils/messages.ts
+++ b/ideeenbord-mvp/ideeenbord/utils/messages.ts
@@ -65,6 +65,7 @@ export type MessageKey =
   | "claim-failed"
   | "request-submitted"
   | "request-failed"
+  | "profanity-detected"
   | "server-error";
 
 type MessageType = "success" | "error" | "warning";
@@ -469,6 +470,13 @@ export const messages: Record<
     text: {
       nl: "Aanvraag mislukt.",
       en: "Brand request failed.",
+    },
+  },
+  "profanity-detected": {
+    type: "error",
+    text: {
+      nl: "Scheldwoorden zijn verboden.",
+      en: "Profanity is not allowed.",
     },
   },
 };

--- a/ideeenbord-mvp/laravel-backend/app/Http/Middleware/CheckProfanity.php
+++ b/ideeenbord-mvp/laravel-backend/app/Http/Middleware/CheckProfanity.php
@@ -1,0 +1,61 @@
+<?php
+
+namespace App\Http\Middleware;
+
+use Closure;
+use Illuminate\Http\Request;
+
+class CheckProfanity
+{
+    public function handle(Request $request, Closure $next)
+    {
+        $banned = config('profanity.words', []);
+        $values = $this->flatten($request->all());
+
+        foreach ($values as $value) {
+            if (!is_string($value)) {
+                continue;
+            }
+            foreach ($banned as $bad) {
+                if ($bad !== '' && stripos($value, $bad) !== false) {
+                    return response()->json(['message' => 'Scheldwoorden zijn verboden.'], 422);
+                }
+            }
+        }
+
+        if ($request->is('api/v1/ideas') && $request->isMethod('post')) {
+            $patterns = [
+                '/\b\d{10}\b/',
+                '/https?:\/\//i',
+                '/www\./i',
+                '/[€$£]/',
+                '/[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,}/i',
+            ];
+            foreach ($values as $value) {
+                if (!is_string($value)) {
+                    continue;
+                }
+                foreach ($patterns as $pattern) {
+                    if (preg_match($pattern, $value)) {
+                        return response()->json(['message' => 'Contactgegevens zijn niet toegestaan in ideeën.'], 422);
+                    }
+                }
+            }
+        }
+
+        return $next($request);
+    }
+
+    private function flatten(array $data): array
+    {
+        $result = [];
+        foreach ($data as $value) {
+            if (is_array($value)) {
+                $result = array_merge($result, $this->flatten($value));
+            } else {
+                $result[] = $value;
+            }
+        }
+        return $result;
+    }
+}

--- a/ideeenbord-mvp/laravel-backend/bootstrap/app.php
+++ b/ideeenbord-mvp/laravel-backend/bootstrap/app.php
@@ -19,6 +19,7 @@ return Application::configure(basePath: dirname(__DIR__))
             'auth' => Authenticate::class,
         ]);
         // $middleware->append(IsAdmin::class);
+        $middleware->append(\App\Http\Middleware\CheckProfanity::class);
     })
     ->withExceptions(function (Exceptions $exceptions) {
         //

--- a/ideeenbord-mvp/laravel-backend/config/profanity.php
+++ b/ideeenbord-mvp/laravel-backend/config/profanity.php
@@ -1,0 +1,7 @@
+<?php
+
+return [
+    'words' => [
+        'fuck', 'shit', 'bitch', 'asshole', 'kut', 'kanker',
+    ],
+];


### PR DESCRIPTION
## Summary
- add middleware `CheckProfanity` in backend
- register middleware in bootstrap app
- store banned words in `config/profanity.php`
- expand messages catalog with `profanity-detected`
- surface profanity errors when registering users, requesting brands and posting ideas

## Testing
- `npm test` *(fails: no script)*
- `npm run lint` *(fails: no script)*
- `php artisan test` *(fails: missing vendor directory)*

------
https://chatgpt.com/codex/tasks/task_e_6870d9bf39bc8330b5501f822eb0c34c