### PR TITLE
Implement profanity filter for brand requests

### DIFF
--- a/ideeenbord-mvp/ideeenbord/pages/brands/request.vue
+++ b/ideeenbord-mvp/ideeenbord/pages/brands/request.vue
@@ -30,7 +30,11 @@ async function handleSubmit() {
     await requestBrand(form.value);
     triggerByKey("request-submitted");
   } catch (e) {
-    triggerByKey("request-failed");
+    if (e === "profanity-detected" || error.value === "profanity-detected") {
+      triggerByKey("profanity-detected");
+    } else {
+      triggerByKey("request-failed");
+    }
   }
 }
 </script>

--- a/ideeenbord-mvp/ideeenbord/utils/messages.ts
+++ b/ideeenbord-mvp/ideeenbord/utils/messages.ts
@@ -56,6 +56,7 @@ export type MessageKey =
   | "idea-unpin-failed"
   | "register-success"
   | "register-failed"
+  | "profanity-detected"
   | "brand-rating-failed"
   | "brand-rating-saved"
   | "brand-already-rated"
@@ -406,6 +407,13 @@ export const messages: Record<
     text: {
       nl: "Registratie mislukt. Probeer het opnieuw.",
       en: "Registration failed. Please try again.",
+    },
+  },
+  "profanity-detected": {
+    type: "error",
+    text: {
+      nl: "Ongepaste taal gedetecteerd.",
+      en: "Inappropriate language detected.",
     },
   },
   "brand-load-failed": {

--- a/ideeenbord-mvp/laravel-backend/app/Rules/ProfanityFree.php
+++ b/ideeenbord-mvp/laravel-backend/app/Rules/ProfanityFree.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace App\Rules;
+
+use Illuminate\Contracts\Validation\Rule;
+
+class ProfanityFree implements Rule
+{
+    protected array $banned = [
+        'fuck',
+        'shit',
+        'bitch',
+        'kut',
+    ];
+
+    public function passes($attribute, $value)
+    {
+        if (! is_string($value)) {
+            return true;
+        }
+
+        $lower = strtolower($value);
+        foreach ($this->banned as $word) {
+            if (str_contains($lower, $word)) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    public function message()
+    {
+        return 'profanity-detected';
+    }
+}


### PR DESCRIPTION
## Summary
- add reusable `ProfanityFree` validation rule
- validate brand request and user registration using this rule
- show correct message when profanity is detected during brand request
- support new message key `profanity-detected`

## Testing
- `composer install` *(fails: 403 Forbidden)*
- `npm install` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_6871497a849c8330819346a6f83631ae