### PR TITLE
Add profanity check for brand requests

### DIFF
--- a/ideeenbord-mvp/ideeenbord/composables/brand/useBrand.ts
+++ b/ideeenbord-mvp/ideeenbord/composables/brand/useBrand.ts
@@ -10,18 +10,18 @@ import type { RequestBrandForm, ClaimForm } from "~/types/brand";
  * - updating brand details (owner only)
  */
 export function useBrand() {
-  const error = ref<string | null>(null);
+  const error = ref<unknown>(null);
 
   /**
    * Submit a request to register a new brand.
    */
   async function requestBrand(form: RequestBrandForm) {
     try {
-      return await brandService.requestBrand(form);
+      await brandService.requestBrand(form);
+      return true;
     } catch (err: any) {
-      error.value =
-        err?.data?.message || "Something went wrong during brand registration.";
-      throw error.value;
+      error.value = err?.response?._data || err?.data || err;
+      return false;
     }
   }
 

--- a/ideeenbord-mvp/ideeenbord/pages/brands/request.vue
+++ b/ideeenbord-mvp/ideeenbord/pages/brands/request.vue
@@ -43,19 +43,21 @@ function firstLaravelMessage(raw: unknown): string | null {
 
 // Submit the form to request a new brand
 async function handleSubmit() {
-  try {
-    await requestBrand(form.value);
-    triggerByKey("request-submitted");
-  } catch (e) {
-    const msg = firstLaravelMessage(error.value);
+  const ok = await requestBrand(form.value);
 
-    if (msg === "profanity-detected") {
-      triggerByKey(msg);
-    } else if (msg) {
-      trigger(msg, "error");
-    } else {
-      triggerByKey("request-failed");
-    }
+  if (ok) {
+    triggerByKey("request-submitted");
+    return;
+  }
+
+  const msg = firstLaravelMessage(error.value);
+
+  if (msg === "profanity-detected") {
+    triggerByKey(msg);
+  } else if (msg) {
+    trigger(msg, "error");
+  } else {
+    triggerByKey("request-failed");
   }
 }
 </script>

--- a/ideeenbord-mvp/laravel-backend/app/Http/Controllers/Brand/BrandController.php
+++ b/ideeenbord-mvp/laravel-backend/app/Http/Controllers/Brand/BrandController.php
@@ -6,7 +6,7 @@ use App\Models\Brand;
 use App\Http\Controllers\Controller;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Storage;
-use Illuminate\Support\Facades\Validator;
+use App\Http\Requests\StoreBrandRequest;
 use Illuminate\Support\Str;
 
 /**
@@ -26,25 +26,9 @@ class BrandController extends Controller
      * @param Request $request The HTTP request containing brand data.
      * @return \Illuminate\Http\JsonResponse The created brand data or validation errors.
      */
-    public function store(Request $request)
+    public function store(StoreBrandRequest $request)
     {
-        $validator = Validator::make($request->all(), [
-            'title' => 'required|string|max:255',
-            'category' => 'required|string|max:255',
-            'website_url' => 'nullable|url',
-            'intro' => 'nullable|string',
-            'intro_short' => 'nullable|string|max:160',
-            'email' => 'required|email|unique:brands,email',
-            'logo' => 'nullable|file|mimes:jpeg,png,jpg,gif|max:2048',
-            'socials' => 'nullable|json',
-        ]);
-
-        if ($validator->fails()) {
-            return response()->json(['errors' => $validator->errors()], 422);
-        }
-
-
-        $data = $validator->validated();
+        $data = $request->validated();
 
         // Handle logo upload
         if ($request->hasFile('logo')) {

--- a/ideeenbord-mvp/laravel-backend/app/Http/Requests/StoreBrandRequest.php
+++ b/ideeenbord-mvp/laravel-backend/app/Http/Requests/StoreBrandRequest.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace App\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+use App\Rules\ProfanityFree;
+
+class StoreBrandRequest extends FormRequest
+{
+    /** Only authenticated users may request a brand */
+    public function authorize(): bool
+    {
+        return $this->user() !== null;
+    }
+
+    /** Validate brand request fields */
+    public function rules(): array
+    {
+        return [
+            'title' => ['required', 'string', 'max:255', new ProfanityFree],
+            'category' => ['required', 'string', 'max:255'],
+            'website_url' => ['nullable', 'url', new ProfanityFree],
+            'intro' => ['nullable', 'string', new ProfanityFree],
+            'intro_short' => ['nullable', 'string', 'max:160', new ProfanityFree],
+            'email' => ['required', 'email', 'unique:brands,email', new ProfanityFree],
+            'logo' => ['nullable', 'file', 'mimes:jpeg,png,jpg,gif', 'max:2048'],
+            'socials' => ['nullable', 'json'],
+        ];
+    }
+
+    /** Custom error messages */
+    public function messages(): array
+    {
+        return [
+            'title.required' => __('Merknaam is verplicht.'),
+            'category.required' => __('Categorie is verplicht.'),
+            'email.required' => __('Email is verplicht.'),
+            'profanity' => __('Ongepaste taal gedetecteerd.'),
+        ];
+    }
+}


### PR DESCRIPTION
## Summary
- create `StoreBrandRequest` FormRequest to validate brand submissions
- update `BrandController` to use the new request
- surface profanity errors when requesting a brand

## Testing
- `npm run lint` *(fails: Missing script)*
- `npm run build` *(fails: nuxt not found)*
- `php artisan test` *(fails: vendor autoload missing)*

------
https://chatgpt.com/codex/tasks/task_e_68714da732d08330b8677f870087b835